### PR TITLE
Workaround. Sometimes something in the chain of SpectraAccess classes

### DIFF
--- a/src/rappsilber/applications/SimpleXiProcess.java
+++ b/src/rappsilber/applications/SimpleXiProcess.java
@@ -799,6 +799,9 @@ public class SimpleXiProcess implements XiProcess {// implements ScoreSpectraMat
                     brw.selfFinished();
                 }
             }
+            String msg = " Looks like for some reason peaklists are not completely read in yet - restarting search ...";
+            m_config.getStatusInterface().setStatus(msg);
+            Logger.getLogger(this.getClass().getName()).log(Level.INFO, msg);
             startSearch();
             waitEnd();
             return;


### PR DESCRIPTION
claims that we already reached the end of a file but we don't really 
did so. Possibly some thread synchronisation problem related to 
MSMListIterator. But for now I just build a workaround that checks twice 
- with a bit of a delay - if we reached the end.